### PR TITLE
Fixed compatiblity with Mongoid 4.x and DelayedJob 4.x.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Next Release
+------------
+
+* Fixed compatibility with Mongoid 4.x and DelayedJob 4.x - [@dblock](http://github.com/dblock).
+
 0.5.1
 -----
 

--- a/delayed_job_shallow_mongoid.gemspec
+++ b/delayed_job_shallow_mongoid.gemspec
@@ -37,9 +37,9 @@ Gem::Specification.new do |s|
   s.summary = "More efficient Mongoid document serialization for delayed_job."
 
   s.specification_version = 3
-  s.add_runtime_dependency(%q<delayed_job>, ["~> 3.0"])
-  s.add_runtime_dependency(%q<delayed_job_mongoid>, ["~> 2.0"])
-  s.add_runtime_dependency(%q<mongoid>, ["~> 3.0"])
+  s.add_runtime_dependency(%q<delayed_job>, [">= 3.0"])
+  s.add_runtime_dependency(%q<delayed_job_mongoid>, [">= 2.0"])
+  s.add_runtime_dependency(%q<mongoid>, [">= 3.0"])
   s.add_development_dependency(%q<actionmailer>, [">= 0"])
   s.add_development_dependency(%q<shoulda>, [">= 0"])
   s.add_development_dependency(%q<rake>, ["~> 10.0"])

--- a/spec/performable_mailer_spec.rb
+++ b/spec/performable_mailer_spec.rb
@@ -4,8 +4,8 @@ describe ::Delayed::PerformableMailer do
   context "successful mailer" do
     before do
       @model = TestModel.create
-      @email = mock('email', :deliver => true)
-      @mailer_class = mock('MailerClass', :signup => @email)
+      @email = double('email', :deliver => true)
+      @mailer_class = double('MailerClass', :signup => @email)
       @mailer = ::Delayed::PerformableMailer.new(@mailer_class, :signup, [@model])
     end
     it "calls the method and #deliver on the mailer" do
@@ -30,9 +30,9 @@ describe ::Delayed::PerformableMailer do
     before do
       @model = TestModel.create
       error = ::Mongoid::Errors::DocumentNotFound.new(TestModel, nil, [ @model._id ])
-      @email = mock('email')
+      @email = double('email')
       @email.stub(:deliver).and_raise(error)
-      @mailer_class = mock('MailerClass', :signup => @email)
+      @mailer_class = double('MailerClass', :signup => @email)
       @mailer = ::Delayed::PerformableMailer.new(@mailer_class, :signup, [@model])
     end
     it "fails if an exception comes up" do

--- a/spec/performable_method_spec.rb
+++ b/spec/performable_method_spec.rb
@@ -36,7 +36,7 @@ describe ::Delayed::PerformableMethod do
       end
       context "with an embedded document" do
         before(:each) do
-          @child = ChildModel.new(:_id => Moped::BSON::ObjectId.new)
+          @child = ChildModel.new
           @model.child_models.push @child
         end
         after(:each) do
@@ -49,7 +49,7 @@ describe ::Delayed::PerformableMethod do
           @method.object.selector.should == ['child_models', ['find', @child._id.to_s]]
         end
         it "stores the deeply nested selector" do
-          @grandchild = GrandchildModel.new(:_id => Moped::BSON::ObjectId.new)
+          @grandchild = GrandchildModel.new
           @model.child_models.first.grandchild_models.push @grandchild
           @method = ::Delayed::PerformableMethod.new(@grandchild, :to_s, [])
           @method.object.selector.should == ['child_models', ['find', @child._id.to_s], 'grandchild_models', ['find', @grandchild._id.to_s]]
@@ -76,7 +76,7 @@ describe ::Delayed::PerformableMethod do
         method.perform.should be_true
       end
       it "finds embedded document" do
-        child = ChildModel.new(:_id => Moped::BSON::ObjectId.new)
+        child = ChildModel.new
         @model.child_models.push child
         method = ::Delayed::PerformableMethod.new(child, :to_s, [])
         TestModel.should_receive(:find).with(@model._id.to_s).and_return(@model)
@@ -94,7 +94,7 @@ describe ::Delayed::PerformableMethod do
         method.display_name.should == "Symbol#to_s"
       end
       it "includes selector when document is embedded" do
-        child = ChildModel.new(:_id => Moped::BSON::ObjectId.new)
+        child = ChildModel.new
         @model.child_models.push child
         method = ::Delayed::PerformableMethod.new(child, :to_s, [])
         method.display_name.should == "TestModel[#{@model._id}].child_models.find(\"#{child._id}\")#to_s"

--- a/spec/support/test_mailer.rb
+++ b/spec/support/test_mailer.rb
@@ -7,6 +7,9 @@ class TestMailer < ActionMailer::Base
       to: "bob@example.com",
       subject: "reticulated spline",
       spline: spline ? 'yes' : 'no'
-    })
+    }) do |format|
+      format.text { render text: 'A spline has been reticulated.' }
+    end
   end
+
 end


### PR DESCRIPTION
If you want to test this with Mongoid 4.x, and since neither Mongoid 4.x nor delayed_job_mongoid compatible with Mongoid 4.x has been released, you need to change Gemfile:

```
gem "mongoid", github: "mongoid/mongoid"
gem "activesupport", "~> 4.0"
gem "delayed_job", "~> 4.0"
gem "delayed_job_mongoid", github: "dblock/delayed_job_mongoid", branch: "mongoid-4x"
gem "actionmailer"
gem "shoulda"
gem "rake"
gem "rspec"
gem "ruby-debug19"
```

Corresponding change PRed into delayed_job_mongoid in https://github.com/collectiveidea/delayed_job_mongoid/pull/43. 
