### PR TITLE
Include all files in the .gemspec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.0.1 (2014-07-02)
+------------------
+
+* Fixed missing file in .gemspec - [@dblock](http://github.com/dblock).
+
 1.0.0 (2014-07-01)
 ------------------
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@ source "http://rubygems.org"
 
 gemspec
 
-case version = ENV['MONGOID_VERSION'] || '~> 3.1'
+case version = ENV['MONGOID_VERSION'] || '~> 4.0'
 when /4/
-  gem 'mongoid', github: 'mongoid/mongoid'
+  gem 'mongoid', '~> 4.0'
 when /3/
   gem 'mongoid', '~> 3.1'
 else

--- a/delayed_job_shallow_mongoid.gemspec
+++ b/delayed_job_shallow_mongoid.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
     "LICENSE.txt",
     "README.md"
   ]
-  s.files = [
+  s.files = Dir[
     ".document",
     ".travis.yml",
     "CHANGELOG.md",
@@ -24,12 +24,7 @@ Gem::Specification.new do |s|
     "README.md",
     "Rakefile",
     "delayed_job_shallow_mongoid.gemspec",
-    "lib/delayed/shallow_mongoid.rb",
-    "lib/delayed/shallow_mongoid/document_stub.rb",
-    "lib/delayed/shallow_mongoid/performable_mailer.rb",
-    "lib/delayed/shallow_mongoid/performable_method.rb",
-    "lib/delayed/shallow_mongoid/version.rb",
-    "lib/delayed_job_shallow_mongoid.rb"
+    'lib/**/*'
   ]
   s.homepage = "http://github.com/joeyAghion/delayed_job_shallow_mongoid"
   s.licenses = ["MIT"]

--- a/lib/delayed/shallow_mongoid/version.rb
+++ b/lib/delayed/shallow_mongoid/version.rb
@@ -1,5 +1,5 @@
 module Delayed
   module ShallowMongoid
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
1.0.0 is toast

```
/Users/dblock/.rvm/gems/ruby-2.0.0-p353/gems/activesupport-4.1.1/lib/active_support/dependencies.rb:247:in `require': cannot load such file -- delayed/shallow_mongoid/mongoid (LoadError)
```
